### PR TITLE
 Add support for eviction-allowed annotation and flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ helm repo update
 helm install soft-pod-memory-evicter maxlaverse/soft-pod-memory-evicter
 ```
 
+## Annotations
+
+The controller will respect the following annotation to decide whether to evict a Pod or not:
+
+```yaml
+soft-pod-memory-evicter/eviction-allowed: "true"
+```
+
 ## Usage
 
 ```
@@ -34,6 +42,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --dry-run                            Output additional debug lines (default: false)
+   --strict-annotation                  Only evict Pods with the annotation 'soft-pod-memory-evicter/eviction-allowed' set to 'true' (default: false)
    --eviction-pause value               Pause duration between evictions (default: 5m0s)
    --memory-usage-check-interval value  Interval at which the Pod metrics are checked (default: 3m0s)
    --memory-usage-threshold value       Memory usage eviction threshold (0-100) (default: 95)

--- a/README.md
+++ b/README.md
@@ -20,14 +20,6 @@ helm repo update
 helm install soft-pod-memory-evicter maxlaverse/soft-pod-memory-evicter
 ```
 
-## Annotations
-
-The controller will respect the following annotation to decide whether to evict a Pod or not:
-
-```yaml
-soft-pod-memory-evicter/eviction-allowed: "true"
-```
-
 ## Usage
 
 ```
@@ -42,7 +34,7 @@ COMMANDS:
 
 GLOBAL OPTIONS:
    --dry-run                            Output additional debug lines (default: false)
-   --strict-annotation                  Only evict Pods with the annotation 'soft-pod-memory-evicter/eviction-allowed' set to 'true' (default: false)
+   --pod-selector value                 Evict only Pods matching this label selector
    --eviction-pause value               Pause duration between evictions (default: 5m0s)
    --memory-usage-check-interval value  Interval at which the Pod metrics are checked (default: 3m0s)
    --memory-usage-threshold value       Memory usage eviction threshold (0-100) (default: 95)

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 func main() {
 	opts := pkg.Options{
 		DryRun:                   false,
+		IsAnnotationRequired:     false,
 		EvictionPause:            time.Duration(5) * time.Minute,
 		MemoryUsageCheckInterval: time.Duration(3) * time.Minute,
 		MemoryUsageThreshold:     95,
@@ -36,6 +37,11 @@ func main() {
 				Usage:       "Output additional debug lines",
 				Value:       opts.DryRun,
 				Destination: &opts.DryRun,
+			}, &cli.BoolFlag{
+				Name:        "strict-annotation",
+				Usage:       "Only evict Pods with the annotation 'soft-pod-memory-evicter/eviction-allowed' set to 'true'",
+				Value:       opts.IsAnnotationRequired,
+				Destination: &opts.IsAnnotationRequired,
 			}, &cli.DurationFlag{
 				Name:        "eviction-pause",
 				Usage:       "Pause duration between evictions",

--- a/main.go
+++ b/main.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/maxlaverse/soft-pod-memory-evicter/pkg"
 	"github.com/urfave/cli/v2"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/klog/v2"
 )
 
 func main() {
 	opts := pkg.Options{
 		DryRun:                   false,
-		IsAnnotationRequired:     false,
+		PodSelector:              pkg.SelectorFlag{Selector: labels.Everything()},
 		EvictionPause:            time.Duration(5) * time.Minute,
 		MemoryUsageCheckInterval: time.Duration(3) * time.Minute,
 		MemoryUsageThreshold:     95,
@@ -37,11 +38,11 @@ func main() {
 				Usage:       "Output additional debug lines",
 				Value:       opts.DryRun,
 				Destination: &opts.DryRun,
-			}, &cli.BoolFlag{
-				Name:        "strict-annotation",
-				Usage:       "Only evict Pods with the annotation 'soft-pod-memory-evicter/eviction-allowed' set to 'true'",
-				Value:       opts.IsAnnotationRequired,
-				Destination: &opts.IsAnnotationRequired,
+			}, &cli.GenericFlag{
+				Name:        "pod-selector",
+				Usage:       "Evict only Pods matching this label selector",
+				Value:       &opts.PodSelector,
+				Destination: &opts.PodSelector,
 			}, &cli.DurationFlag{
 				Name:        "eviction-pause",
 				Usage:       "Pause duration between evictions",

--- a/pkg/controller_test.go
+++ b/pkg/controller_test.go
@@ -135,7 +135,7 @@ var (
 		},
 		metrics: metricsv1beta1.PodMetrics{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod-3",
+				Name:      "test-pod-4",
 				Namespace: "test-namespace",
 			},
 			Containers: []metricsv1beta1.ContainerMetrics{
@@ -265,7 +265,7 @@ func TestEvictionOnlyAffectsPodsMaxingoutMemory(t *testing.T) {
 	assert.Equal(t, "/v1, Resource=pods", action5.GetResource().String())
 
 	obj3 := action5.(clientgo_testing.CreateAction).GetObject()
-	assert.Equal(t, "test-pod-3", obj3.(*policyv1.Eviction).Name)
+	assert.Equal(t, "test-pod-4", obj3.(*policyv1.Eviction).Name)
 	assert.Equal(t, "test-namespace", obj3.(*policyv1.Eviction).Namespace)
 	assert.Nil(t, obj3.(*policyv1.Eviction).DeleteOptions)
 }

--- a/pkg/controller_test.go
+++ b/pkg/controller_test.go
@@ -314,10 +314,19 @@ func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationOptOut(t *testing.T
 
 	err := c.evictPodsCloseToMemoryLimit(context.Background())
 	assert.NoError(t, err)
-	c.sync()
+	c.terminate_graceful()
 
 	fakeClientSet := c.clientset.(*fake.Clientset)
-	assert.Equal(t, 4, len(fakeClientSet.Actions())) // pod, podmetrics, pdb, eviction
+	assert.Equal(t, 5, len(fakeClientSet.Actions()))
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "poddisruptionbudgets")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "poddisruptionbudgets")
+
+	action4 := fakeClientSet.Actions()[4]
+	assert.Equal(t, "create", action4.GetVerb())
+	assert.Equal(t, "eviction", action4.GetSubresource())
+	assert.Equal(t, "/v1, Resource=pods", action4.GetResource().String())
 }
 
 func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationToFalseOptOut(t *testing.T) {
@@ -326,10 +335,14 @@ func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationToFalseOptOut(t *te
 
 	err := c.evictPodsCloseToMemoryLimit(context.Background())
 	assert.NoError(t, err)
-	c.sync()
+	c.terminate_graceful()
 
 	fakeClientSet := c.clientset.(*fake.Clientset)
-	assert.Equal(t, 2, len(fakeClientSet.Actions())) // pod, podmetrics (no eviction)
+	assert.Equal(t, 4, len(fakeClientSet.Actions()))
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "poddisruptionbudgets")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "poddisruptionbudgets")
 }
 
 func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationOptIn(t *testing.T) {
@@ -338,10 +351,19 @@ func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationOptIn(t *testing.T)
 
 	err := c.evictPodsCloseToMemoryLimit(context.Background())
 	assert.NoError(t, err)
-	c.sync()
+	c.terminate_graceful()
 
 	fakeClientSet := c.clientset.(*fake.Clientset)
-	assert.Equal(t, 4, len(fakeClientSet.Actions())) // pod, podmetrics, pdb, eviction
+	assert.Equal(t, 5, len(fakeClientSet.Actions()))
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "poddisruptionbudgets")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "poddisruptionbudgets")
+
+	action4 := fakeClientSet.Actions()[4]
+	assert.Equal(t, "create", action4.GetVerb())
+	assert.Equal(t, "eviction", action4.GetSubresource())
+	assert.Equal(t, "/v1, Resource=pods", action4.GetResource().String())
 }
 
 func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationToFalseOptIn(t *testing.T) {
@@ -350,10 +372,14 @@ func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationToFalseOptIn(t *tes
 
 	err := c.evictPodsCloseToMemoryLimit(context.Background())
 	assert.NoError(t, err)
-	c.sync()
+	c.terminate_graceful()
 
 	fakeClientSet := c.clientset.(*fake.Clientset)
-	assert.Equal(t, 2, len(fakeClientSet.Actions())) // pod, podmetrics (no eviction)
+	assert.Equal(t, 4, len(fakeClientSet.Actions()))
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "poddisruptionbudgets")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "poddisruptionbudgets")
 }
 
 func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithoutAnnotationToFalseOptIn(t *testing.T) {
@@ -362,10 +388,14 @@ func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithoutAnnotationToFalseOptIn(t *
 
 	err := c.evictPodsCloseToMemoryLimit(context.Background())
 	assert.NoError(t, err)
-	c.sync()
+	c.terminate_graceful()
 
 	fakeClientSet := c.clientset.(*fake.Clientset)
-	assert.Equal(t, 2, len(fakeClientSet.Actions())) // pod, podmetrics (no eviction)
+	assert.Equal(t, 4, len(fakeClientSet.Actions()))
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "pods")
+	assertContainsAction(t, fakeClientSet.Actions(), "list", "poddisruptionbudgets")
+	assertContainsAction(t, fakeClientSet.Actions(), "watch", "poddisruptionbudgets")
 }
 
 func TestEvictionAlsoWorksForPodsWithDisruptionBudget(t *testing.T) {

--- a/pkg/controller_test.go
+++ b/pkg/controller_test.go
@@ -10,6 +10,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -145,32 +146,30 @@ var (
 	}
 
 	// A Pod with one container that is maxed out having the annotation
-	podSingleMaxedoutContainerWithAnnotation = func(annotationValue string) testPod {
-		return testPod{
-			pod: corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod-4",
-					Namespace: "test-namespace",
-					Annotations: map[string]string{
-						"soft-pod-memory-evicter/eviction-allowed": annotationValue,
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						containerDefinitionWithMemoryLimit("container-1", "1Gi"),
-					},
+	podSingleMaxedoutContainerWithAnnotation = testPod{
+		pod: corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod-4",
+				Namespace: "test-namespace",
+				Labels: map[string]string{
+					"soft-pod-memory-evicter/eviction-allowed": "true",
 				},
 			},
-			metrics: metricsv1beta1.PodMetrics{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod-4",
-					Namespace: "test-namespace",
-				},
-				Containers: []metricsv1beta1.ContainerMetrics{
-					containerMetricsWithMemoryUsage("container-1", "1Gi"),
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					containerDefinitionWithMemoryLimit("container-1", "1Gi"),
 				},
 			},
-		}
+		},
+		metrics: metricsv1beta1.PodMetrics{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-pod-4",
+				Namespace: "test-namespace",
+			},
+			Containers: []metricsv1beta1.ContainerMetrics{
+				containerMetricsWithMemoryUsage("container-1", "1Gi"),
+			},
+		},
 	}
 
 	// A pod with one container that is maxed out having a PodDisruptionBudget
@@ -308,9 +307,9 @@ func TestEvictionHasDryrunSet(t *testing.T) {
 	assert.Equal(t, "All", obj3.(*policyv1.Eviction).DeleteOptions.DryRun[0])
 }
 
-func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationOptOut(t *testing.T) {
-	c := fakeController(podSingleMaxedoutContainerWithAnnotation("true"))
-	c.opts.IsAnnotationRequired = false
+func TestEvictionAffectsPodsMaxingoutMemoryMatchingSelector(t *testing.T) {
+	c := fakeController(podSingleMaxedoutContainerWithAnnotation)
+	c.opts.PodSelector.Selector = labels.Set{"soft-pod-memory-evicter/eviction-allowed": "true"}.AsSelector()
 
 	err := c.evictPodsCloseToMemoryLimit(context.Background())
 	assert.NoError(t, err)
@@ -329,62 +328,9 @@ func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationOptOut(t *testing.T
 	assert.Equal(t, "/v1, Resource=pods", action4.GetResource().String())
 }
 
-func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationToFalseOptOut(t *testing.T) {
-	c := fakeController(podSingleMaxedoutContainerWithAnnotation("false"))
-	c.opts.IsAnnotationRequired = false
-
-	err := c.evictPodsCloseToMemoryLimit(context.Background())
-	assert.NoError(t, err)
-	c.terminate_graceful()
-
-	fakeClientSet := c.clientset.(*fake.Clientset)
-	assert.Equal(t, 4, len(fakeClientSet.Actions()))
-	assertContainsAction(t, fakeClientSet.Actions(), "list", "pods")
-	assertContainsAction(t, fakeClientSet.Actions(), "watch", "pods")
-	assertContainsAction(t, fakeClientSet.Actions(), "list", "poddisruptionbudgets")
-	assertContainsAction(t, fakeClientSet.Actions(), "watch", "poddisruptionbudgets")
-}
-
-func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationOptIn(t *testing.T) {
-	c := fakeController(podSingleMaxedoutContainerWithAnnotation("true"))
-	c.opts.IsAnnotationRequired = true
-
-	err := c.evictPodsCloseToMemoryLimit(context.Background())
-	assert.NoError(t, err)
-	c.terminate_graceful()
-
-	fakeClientSet := c.clientset.(*fake.Clientset)
-	assert.Equal(t, 5, len(fakeClientSet.Actions()))
-	assertContainsAction(t, fakeClientSet.Actions(), "list", "pods")
-	assertContainsAction(t, fakeClientSet.Actions(), "watch", "pods")
-	assertContainsAction(t, fakeClientSet.Actions(), "list", "poddisruptionbudgets")
-	assertContainsAction(t, fakeClientSet.Actions(), "watch", "poddisruptionbudgets")
-
-	action4 := fakeClientSet.Actions()[4]
-	assert.Equal(t, "create", action4.GetVerb())
-	assert.Equal(t, "eviction", action4.GetSubresource())
-	assert.Equal(t, "/v1, Resource=pods", action4.GetResource().String())
-}
-
-func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithAnnotationToFalseOptIn(t *testing.T) {
-	c := fakeController(podSingleMaxedoutContainerWithAnnotation("false"))
-	c.opts.IsAnnotationRequired = true
-
-	err := c.evictPodsCloseToMemoryLimit(context.Background())
-	assert.NoError(t, err)
-	c.terminate_graceful()
-
-	fakeClientSet := c.clientset.(*fake.Clientset)
-	assert.Equal(t, 4, len(fakeClientSet.Actions()))
-	assertContainsAction(t, fakeClientSet.Actions(), "list", "pods")
-	assertContainsAction(t, fakeClientSet.Actions(), "watch", "pods")
-	assertContainsAction(t, fakeClientSet.Actions(), "list", "poddisruptionbudgets")
-	assertContainsAction(t, fakeClientSet.Actions(), "watch", "poddisruptionbudgets")
-}
-
-func TestEvictionOnlyAffectsPodsMaxingoutMemoryWithoutAnnotationToFalseOptIn(t *testing.T) {
-	c := fakeController(podSingleMaxedoutContainer)
-	c.opts.IsAnnotationRequired = true
+func TestEvictionDoesnotAffectsPodsMaxingoutMemoryNotMatchingSelector(t *testing.T) {
+	c := fakeController(podSingleMaxedoutContainerWithAnnotation)
+	c.opts.PodSelector.Selector = labels.Nothing()
 
 	err := c.evictPodsCloseToMemoryLimit(context.Background())
 	assert.NoError(t, err)
@@ -460,6 +406,7 @@ func fakeController(podConfigs ...testPod) *controller {
 		podMetrics: dummyPodMetricLister{Items: podMetrics},
 		opts: Options{
 			MemoryUsageThreshold: 90,
+			PodSelector:          SelectorFlag{Selector: labels.Everything()},
 		},
 	}
 }

--- a/pkg/options.go
+++ b/pkg/options.go
@@ -1,0 +1,61 @@
+package pkg
+
+import (
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+type SelectorFlag struct {
+	Selector labels.Selector
+}
+
+func (selectorFlag *SelectorFlag) Set(value string) error {
+	labelSelector, err := metav1.ParseToLabelSelector(value)
+	if err != nil {
+		return err
+	}
+	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
+	if err != nil {
+		return err
+	}
+	selectorFlag.Selector = selector
+	return nil
+}
+
+func (selectorFlag *SelectorFlag) String() string {
+	if selectorFlag.Selector == nil {
+		return ""
+	}
+	return selectorFlag.Selector.String()
+}
+
+type Options struct {
+	// DryRun=true won't evict Pods for real
+	DryRun bool
+
+	// PodSelector is the selector used to list pods, allowing inclusion or
+	// exclusion of specific Pods.
+	PodSelector SelectorFlag
+
+	// MemoryUsageThreshold is the threshold (0-100) above which a Pod is considered
+	// as overusing its memory.
+	MemoryUsageThreshold int
+
+	// EvictionPause is the delay we wait between two evictions, to prevent
+	// removing too many Pods at once. Else we could more easily have downtimes if
+	// Deployments don't specify a PodDisruptionBudget. Pods defining a
+	// PodDisruptionBudget will ignore the pause, but respecting the budget.
+	EvictionPause time.Duration
+
+	// MemoryUsageCheckInterval is how often we check the memory usage.
+	// It doesn't need to be too frequent, as we have to wait for the metric-server
+	// to refresh the metrics all the time.
+	MemoryUsageCheckInterval time.Duration
+
+	// ChannelQueueSize is the size of the queue for Pods to evict.
+	// It is filled each check interval and drained by the eviction loops. Eviction
+	// pauses and backoffs cause the queue to fill up.
+	ChannelQueueSize int
+}


### PR DESCRIPTION
This pull request introduces the ability to respect the eviction-allowed annotation and flag when deciding whether to evict a Pod.

Addresses https://github.com/maxlaverse/soft-pod-memory-evicter/issues/112