### PR TITLE
Add flag to allow ignoring individual namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ COMMANDS:
    help, h  Shows a list of commands or help for one command
 
 GLOBAL OPTIONS:
-   --dry-run                            Output additional debug lines (default: false)
-   --eviction-pause value               Pause duration between evictions (default: 5m0s)
-   --memory-usage-check-interval value  Interval at which the Pod metrics are checked (default: 3m0s)
-   --memory-usage-threshold value       Memory usage eviction threshold (0-100) (default: 95)
-   --channel-queue-size value           Size of the queue for pod eviction (default: 100)
-   --loglevel value, -v value           Log Level (default: 0)
-   --help, -h                           show help
+   --dry-run                                              Output additional debug lines (default: false)
+   --eviction-pause value                                 Pause duration between evictions (default: 5m0s)
+   --memory-usage-check-interval value                    Interval at which the Pod metrics are checked (default: 3m0s)
+   --memory-usage-threshold value                         Memory usage eviction threshold (0-100) (default: 95)
+   --channel-queue-size value                             Size of the queue for pod eviction (default: 100)
+   --ignore-namespace value [ --ignore-namespace value ]  Do not evict Pods from this namespace. Can be used multiple times
+   --loglevel value, -v value                             Log Level (default: 0)
+   --help, -h                                             show help
 ```
 
 ## License

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ func main() {
 		MemoryUsageCheckInterval: time.Duration(3) * time.Minute,
 		MemoryUsageThreshold:     95,
 		ChannelQueueSize:         100,
+		IgnoredNamespaces:        *cli.NewStringSlice(),
 	}
 
 	app := &cli.App{
@@ -56,7 +57,13 @@ func main() {
 				Usage:       "Size of the queue for pod eviction",
 				Value:       opts.ChannelQueueSize,
 				Destination: &opts.ChannelQueueSize,
-			}, &cli.IntFlag{
+			}, &cli.StringSliceFlag{
+				Name:        "ignore-namespace",
+				Usage:       "Do not evict Pods from this namespace. Can be used multiple times",
+				Value:       &opts.IgnoredNamespaces,
+				Destination: &opts.IgnoredNamespaces,
+			},
+			&cli.IntFlag{
 				Name:    "loglevel",
 				Aliases: []string{"v"},
 				Usage:   "Log Level",


### PR DESCRIPTION
Adds a flag that enables users of this controller to ignore certain namespaces, e.g. `kube-system`.

An alternative approach I thought about was to support the annotation from https://github.com/maxlaverse/soft-pod-memory-evicter/pull/118 in namespaces. This would require another lister for namespaces though. Not sure if that is worth the effort as I would guess this flag will be used at most with one or two parameters, set by the cluster operators only anyway.